### PR TITLE
fix: disable Wikipedia `auto_suggest` to avoid disambiguation errors

### DIFF
--- a/ch3/sample_Create_Doc_from_Wiki.py
+++ b/ch3/sample_Create_Doc_from_Wiki.py
@@ -2,6 +2,7 @@ from llama_index.readers.wikipedia import WikipediaReader
 
 loader = WikipediaReader() 
 documents = loader.load_data(
-    pages=['Pythagorean theorem','General relativity']
+    pages=['Pythagorean theorem','General relativity'],
+    auto_suggest=False,
 ) 
 print(f"loaded {len(documents)} documents")


### PR DESCRIPTION
This fixes an issue where `WikipediaReader` might fetch disambiguation pages unless `auto_suggest=False` is passed explicitly. Without this, for "General relativity", it was returning "general relativeity" causing `PageError`.